### PR TITLE
Fixed placeholder label layout - it should calculate bounds consideri…

### DIFF
--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -382,8 +382,10 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
     CGFloat padding = self.textContainer.lineFragmentPadding;
     
     CGRect rect = CGRectZero;
-    rect.size.height = [self.placeholderLabel sizeThatFits:bounds.size].height;
-    rect.size.width = self.textContainer.size.width - padding*2.0;
+    CGSize size = bounds.size;
+    size.width = self.textContainer.size.width - padding*2.0;
+    rect.size.height = [self.placeholderLabel sizeThatFits:size].height;
+    rect.size.width = size.width;
     rect.origin = UIEdgeInsetsInsetRect(bounds, self.textContainerInset).origin;
     rect.origin.x += padding;
     


### PR DESCRIPTION
…ng label width, not bounds width

* [ ] I've read and understood the [Contributing guidelines](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://github.com/slackhq/SlackTextViewController/blob/master/.github/CODE_OF_CONDUCT.md).
* [ ] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [ ] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
Fixed placeholder label layout - it should calculate bounds considering label width, not bounds width

#### Related Issues
> e.g. Fixes #206 and closes #230

#### Test strategy
> e.g. Add tests around whatsit production.